### PR TITLE
Refactor Tag component to use React.forwardRef

### DIFF
--- a/components/ui/tag.tsx
+++ b/components/ui/tag.tsx
@@ -41,10 +41,15 @@ export interface TagProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof tagVariants> {}
 
-function Tag({ className, variant, size, ...props }: TagProps) {
-  return (
-    <div className={cn(tagVariants({ variant, size }), className)} {...props} />
-  );
-}
+const Tag = React.forwardRef<HTMLDivElement, TagProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(tagVariants({ variant, size }), className)}
+      {...props}
+    />
+  ),
+);
+Tag.displayName = "Tag";
 
 export { Tag, tagVariants };


### PR DESCRIPTION
- Converted Tag from a function component to a forwardRef component
- Added ref prop to allow passing refs to the underlying div element
- Added displayName for better debugging and component identification